### PR TITLE
Import based on platform

### DIFF
--- a/models/multimodal/text_to_image/stable_diffusion/sd_optimizations_v2.patch
+++ b/models/multimodal/text_to_image/stable_diffusion/sd_optimizations_v2.patch
@@ -301,7 +301,7 @@ new file mode 100644
 index 00000000..dc4a7fb5
 --- /dev/null
 +++ b/src/diffusers/pipelines/aic_utils.py
-@@ -0,0 +1,153 @@
+@@ -0,0 +1,154 @@
 +##############################################################################
 +#
 +# Copyright (c) 2019-2022 Qualcomm Technologies, Inc.
@@ -324,7 +324,8 @@ index 00000000..dc4a7fb5
 +
 +import numpy as np
 +
-+sys.path.append("/opt/qti-aic/dev/lib/x86_64/")
++import platform
++sys.path.append(f"/opt/qti-aic/dev/lib/{platform.machine()}/")
 +sys.path.append('/opt/qti-aic/dev/python/')
 +
 +import QAicApi_pb2 as aicapi


### PR DESCRIPTION
Stable diffusion fails on ARM due to incorrect import path. Updated the import path.

Tested on both x86 and ARM and verified that the updated scripts work on both.