### PR TITLE
Update copyright markings to the modern policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023, Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted (subject to the limitations in the
@@ -12,7 +12,7 @@ disclaimer below) provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Qualcomm Innovation Center, Inc. nor the names of its
+    * Neither the name of Qualcomm Technologies, Inc. nor the names of its
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/compileModel.sh
+++ b/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/compileModel.sh
@@ -2,7 +2,7 @@
 
 ##############################################################################
 #
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 ##############################################################################

--- a/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/generateModel.py
+++ b/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/generateModel.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 ##############################################################################

--- a/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/generateONNX.py
+++ b/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/generateONNX.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 ##############################################################################

--- a/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/qaic_infer.py
+++ b/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/qaic_infer.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 ##############################################################################

--- a/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/runSpeculativeDecoding.sh
+++ b/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/runSpeculativeDecoding.sh
@@ -2,7 +2,7 @@
 
 ##############################################################################
 #
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 ##############################################################################

--- a/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/speculativeDecoding.py
+++ b/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/speculativeDecoding.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 ##############################################################################

--- a/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/tlm_modeling_codegen.py
+++ b/models/language_processing/decoder/CodeGen-With-Speculative-Decoding/tlm_modeling_codegen.py
@@ -15,7 +15,7 @@
 
 ##############################################################################
 #
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 ##############################################################################

--- a/models/language_processing/decoder/DeciCoder-6b/generateModel.py
+++ b/models/language_processing/decoder/DeciCoder-6b/generateModel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import os

--- a/models/language_processing/decoder/DeciCoder-6b/qaic_infer.py
+++ b/models/language_processing/decoder/DeciCoder-6b/qaic_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 from typing import Dict, List

--- a/models/language_processing/decoder/DeciCoder-6b/runModel.py
+++ b/models/language_processing/decoder/DeciCoder-6b/runModel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import json

--- a/models/language_processing/decoder/DeciCoder-6b/util.py
+++ b/models/language_processing/decoder/DeciCoder-6b/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import argparse

--- a/models/language_processing/decoder/GPTBigCodeForCausalLM/generateModel.py
+++ b/models/language_processing/decoder/GPTBigCodeForCausalLM/generateModel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import argparse

--- a/models/language_processing/decoder/GPTBigCodeForCausalLM/generateONNX.py
+++ b/models/language_processing/decoder/GPTBigCodeForCausalLM/generateONNX.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import os

--- a/models/language_processing/decoder/GPTBigCodeForCausalLM/prepare_jsons.py
+++ b/models/language_processing/decoder/GPTBigCodeForCausalLM/prepare_jsons.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 def main(bs, pl, cl, cores, socs):

--- a/models/language_processing/decoder/GPTBigCodeForCausalLM/qaic_infer.py
+++ b/models/language_processing/decoder/GPTBigCodeForCausalLM/qaic_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 from typing import Dict, List

--- a/models/language_processing/decoder/GPTBigCodeForCausalLM/runModel.py
+++ b/models/language_processing/decoder/GPTBigCodeForCausalLM/runModel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import json

--- a/models/language_processing/decoder/LlamaForCausalLM/generateModel.py
+++ b/models/language_processing/decoder/LlamaForCausalLM/generateModel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import argparse

--- a/models/language_processing/decoder/LlamaForCausalLM/generateONNX.py
+++ b/models/language_processing/decoder/LlamaForCausalLM/generateONNX.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import os

--- a/models/language_processing/decoder/LlamaForCausalLM/runModel.py
+++ b/models/language_processing/decoder/LlamaForCausalLM/runModel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 import json
 import os

--- a/models/language_processing/encoder/run_nlp_model.py
+++ b/models/language_processing/encoder/run_nlp_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import os

--- a/models/multimodal/text_to_image/DeciDiffusion-v2-0/aic_inference_example.py
+++ b/models/multimodal/text_to_image/DeciDiffusion-v2-0/aic_inference_example.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import os.path

--- a/models/multimodal/text_to_image/DeciDiffusion-v2-0/diffusion_to_onnx.py
+++ b/models/multimodal/text_to_image/DeciDiffusion-v2-0/diffusion_to_onnx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import argparse

--- a/models/multimodal/text_to_image/sdxl_deepcache/README.md
+++ b/models/multimodal/text_to_image/sdxl_deepcache/README.md
@@ -1,4 +1,4 @@
-### Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+### Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 ### SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # Instructions to run SDXL on Cloud AI 100 with DeepCache

--- a/models/multimodal/text_to_image/sdxl_deepcache/device_utils.py
+++ b/models/multimodal/text_to_image/sdxl_deepcache/device_utils.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/multimodal/text_to_image/sdxl_deepcache/main.py
+++ b/models/multimodal/text_to_image/sdxl_deepcache/main.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/multimodal/text_to_image/sdxl_deepcache/onnx_generation/generate_onnx_files.py
+++ b/models/multimodal/text_to_image/sdxl_deepcache/onnx_generation/generate_onnx_files.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 import time

--- a/models/multimodal/text_to_image/sdxl_deepcache/onnx_generation/onnx_gen_utils.py
+++ b/models/multimodal/text_to_image/sdxl_deepcache/onnx_generation/onnx_gen_utils.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 from packaging import version

--- a/models/multimodal/text_to_image/sdxl_deepcache/patches/attention_patch.patch
+++ b/models/multimodal/text_to_image/sdxl_deepcache/patches/attention_patch.patch
@@ -7,7 +7,7 @@ index 21eb3a3..d43b51e 100644
  # See the License for the specific language governing permissions and
  # limitations under the License.
 +#
-+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
++# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 +# SPDX-License-Identifier: BSD-3-Clause-Clear
 +# Not a Contribution 
  from importlib import import_module

--- a/models/multimodal/text_to_image/sdxl_deepcache/patches/deepcache_pipeline.patch
+++ b/models/multimodal/text_to_image/sdxl_deepcache/patches/deepcache_pipeline.patch
@@ -7,7 +7,7 @@ index 41decf9..0c8e978 100644
  # See the License for the specific language governing permissions and
  # limitations under the License.
 +#
-+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
++# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 +# SPDX-License-Identifier: BSD-3-Clause-Clear
 +# Not a Contribution 
  

--- a/models/multimodal/text_to_image/sdxl_deepcache/patches/deepcache_unet.patch
+++ b/models/multimodal/text_to_image/sdxl_deepcache/patches/deepcache_unet.patch
@@ -7,7 +7,7 @@ index 6c97199..f6865c6 100644
  # See the License for the specific language governing permissions and
  # limitations under the License.
 +#
-+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
++# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 +# SPDX-License-Identifier: BSD-3-Clause-Clear
 +# Not a Contribution 
  from dataclasses import dataclass

--- a/models/multimodal/text_to_image/sdxl_deepcache/run_config_deep.sh
+++ b/models/multimodal/text_to_image/sdxl_deepcache/run_config_deep.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/multimodal/text_to_image/sdxl_deepcache/run_config_inference.sh
+++ b/models/multimodal/text_to_image/sdxl_deepcache/run_config_inference.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/multimodal/text_to_image/sdxl_deepcache/run_config_shallow.sh
+++ b/models/multimodal/text_to_image/sdxl_deepcache/run_config_shallow.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/multimodal/text_to_image/sdxl_deepcache/utils.py
+++ b/models/multimodal/text_to_image/sdxl_deepcache/utils.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/multimodal/text_to_image/stable_diffusion/aic_inference_dps.py
+++ b/models/multimodal/text_to_image/stable_diffusion/aic_inference_dps.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear
 """
 from diffusers import OnnxStableDiffusionPipeline, OnnxStableDiffusionInpaintPipeline

--- a/models/multimodal/text_to_image/stable_diffusion/compile_models.sh
+++ b/models/multimodal/text_to_image/stable_diffusion/compile_models.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/multimodal/text_to_image/stable_diffusion/generateModels.py
+++ b/models/multimodal/text_to_image/stable_diffusion/generateModels.py
@@ -1,6 +1,6 @@
 
 """
-Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear
 """
 

--- a/models/multimodal/text_to_image/stable_diffusion_xl/README.md
+++ b/models/multimodal/text_to_image/stable_diffusion_xl/README.md
@@ -1,5 +1,5 @@
 
-### Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+### Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 ### SPDX-License-Identifier: BSD-3-Clause-Clear
 
 

--- a/models/multimodal/text_to_image/stable_diffusion_xl/compile_models.sh
+++ b/models/multimodal/text_to_image/stable_diffusion_xl/compile_models.sh
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 #!/bin/bash

--- a/models/multimodal/text_to_image/stable_diffusion_xl/fix_vae_decoder_onnx.py
+++ b/models/multimodal/text_to_image/stable_diffusion_xl/fix_vae_decoder_onnx.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 import onnx

--- a/models/multimodal/text_to_image/stable_diffusion_xl/generate_onnx_files.py
+++ b/models/multimodal/text_to_image/stable_diffusion_xl/generate_onnx_files.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 import time

--- a/models/multimodal/text_to_image/stable_diffusion_xl/onnx_gen_utils.py
+++ b/models/multimodal/text_to_image/stable_diffusion_xl/onnx_gen_utils.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 from packaging import version

--- a/models/multimodal/text_to_image/stable_diffusion_xl/run_sdxl.py
+++ b/models/multimodal/text_to_image/stable_diffusion_xl/run_sdxl.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/speech/whisper/generateModel.py
+++ b/models/speech/whisper/generateModel.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/speech/whisper/runModel.py
+++ b/models/speech/whisper/runModel.py
@@ -1,5 +1,5 @@
 ####################################################################################################
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ####################################################################################################
 

--- a/models/vision/classification/run_cv_classifier.py
+++ b/models/vision/classification/run_cv_classifier.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import os

--- a/models/vision/detection/run_yolo_model.py
+++ b/models/vision/detection/run_yolo_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import os

--- a/samples/cpp/cpp_qpc_inference/CMakeLists.txt
+++ b/samples/cpp/cpp_qpc_inference/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ==============================================================================
 #
-# Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 # ==============================================================================

--- a/samples/cpp/cpp_qpc_inference/main.cpp
+++ b/samples/cpp/cpp_qpc_inference/main.cpp
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 //-----------------------------------------------------------------------------
 

--- a/samples/python/common_utils.py
+++ b/samples/python/common_utils.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear
 '''
 

--- a/samples/python/qaic_features/benchmarking_eg.py
+++ b/samples/python/qaic_features/benchmarking_eg.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear
 '''
 

--- a/samples/python/qaic_features/metrics_eg.py
+++ b/samples/python/qaic_features/metrics_eg.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear
 '''
 

--- a/samples/python/qaic_features/profiling_eg.py
+++ b/samples/python/qaic_features/profiling_eg.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear
 '''
 

--- a/samples/python/vit_qaic/example.py
+++ b/samples/python/vit_qaic/example.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear
 '''
 

--- a/tutorials/Computer-Vision/Perfomance-Tuning-Beginner/Performance-tuning.ipynb
+++ b/tutorials/Computer-Vision/Perfomance-Tuning-Beginner/Performance-tuning.ipynb
@@ -5,7 +5,7 @@
    "id": "726c324c",
    "metadata": {},
    "source": [
-    "Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>\r",
+    "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>\r",
     " SPDX-License-Identifier: BSD-3-Clause-Clear"
    ]
   },

--- a/tutorials/Computer-Vision/Perfomance-Tuning-Beginner/latency_stats_python3.py
+++ b/tutorials/Computer-Vision/Perfomance-Tuning-Beginner/latency_stats_python3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import numpy as np

--- a/tutorials/NLP/Model-Onboarding-Beginner/getting-started-beginner-qa.ipynb
+++ b/tutorials/NLP/Model-Onboarding-Beginner/getting-started-beginner-qa.ipynb
@@ -5,7 +5,7 @@
    "id": "8a58acd8",
    "metadata": {},
    "source": [
-    "Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>\n",
+    "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>\n",
     "SPDX-License-Identifier: BSD-3-Clause-Clear"
    ]
   },

--- a/tutorials/NLP/Model-Onboarding-Beginner/getting-started-beginner-threading.ipynb
+++ b/tutorials/NLP/Model-Onboarding-Beginner/getting-started-beginner-threading.ipynb
@@ -5,7 +5,7 @@
    "id": "0995b8bc",
    "metadata": {},
    "source": [
-    "Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>\n",
+    "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>\n",
     "SPDX-License-Identifier: BSD-3-Clause-Clear"
    ]
   },

--- a/tutorials/NLP/Model-Onboarding-Beginner/getting-started-beginner.ipynb
+++ b/tutorials/NLP/Model-Onboarding-Beginner/getting-started-beginner.ipynb
@@ -5,7 +5,7 @@
    "id": "8a58acd8",
    "metadata": {},
    "source": [
-    "Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>\n",
+    "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>\n",
     "SPDX-License-Identifier: BSD-3-Clause-Clear"
    ]
   },

--- a/tutorials/NLP/Performance-Tuning-Beginner/Performance-tuning.ipynb
+++ b/tutorials/NLP/Performance-Tuning-Beginner/Performance-tuning.ipynb
@@ -5,7 +5,7 @@
    "id": "726c324c",
    "metadata": {},
    "source": [
-    "Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>\n",
+    "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>\n",
     "SPDX-License-Identifier: BSD-3-Clause-Clear"
    ]
   },

--- a/tutorials/NLP/Performance-Tuning-Beginner/latency_stats_python3.py
+++ b/tutorials/NLP/Performance-Tuning-Beginner/latency_stats_python3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 

--- a/tutorials/NLP/Profiler-Intermediate/Profiler-LLM.ipynb
+++ b/tutorials/NLP/Profiler-Intermediate/Profiler-LLM.ipynb
@@ -5,7 +5,7 @@
    "id": "deb291a6",
    "metadata": {},
    "source": [
-    "Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>\n",
+    "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>\n",
     "SPDX-License-Identifier: BSD-3-Clause-Clear"
    ]
   },

--- a/tutorials/NLP/Profiler-Intermediate/Profiler.ipynb
+++ b/tutorials/NLP/Profiler-Intermediate/Profiler.ipynb
@@ -5,7 +5,7 @@
    "id": "deb291a6",
    "metadata": {},
    "source": [
-    "Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved. <br>\n",
+    "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. <br>\n",
     "SPDX-License-Identifier: BSD-3-Clause-Clear"
    ]
   },

--- a/tutorials/NLP/Profiler-Intermediate/latency_stats_python3.py
+++ b/tutorials/NLP/Profiler-Intermediate/latency_stats_python3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import numpy as np

--- a/utils/multi-device/QAicChangeAcs.py
+++ b/utils/multi-device/QAicChangeAcs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 import pyudev


### PR DESCRIPTION
Move to using a yearless, Qualcomm Technologies Inc copyright instead of the existing dated Qualcomm Innovation Center copyrights.